### PR TITLE
supports database options

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -89,9 +89,34 @@ def parse(url, engine=None):
         'PORT': url.port or '',
     })
 
+    # Parse the query string into OPTIONS.
+    qs = urlparse.parse_qs(url.query)
+    options = {}
+    for k in qs:
+        options[k] = qs[k][-1]
+    if options:
+        config['OPTIONS'] = options
+
     if engine:
         config['ENGINE'] = engine
     elif url.scheme in SCHEMES:
         config['ENGINE'] = SCHEMES[url.scheme]
 
     return config
+
+
+def main():
+    import django.db
+    from django.conf import settings
+    default = django.db.DEFAULT_DB_ALIAS
+    settings.configure()
+    settings.DATABASES[default] =  config()
+    db = django.db.connections[default]
+    db.connect()
+    import pprint
+    pprint.pprint(db.settings_dict)
+    print db.is_usable()
+
+
+if __name__ == "__main__":
+    main()

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -111,5 +111,26 @@ class DatabaseTestSuite(unittest.TestCase):
 
         assert url['ENGINE'] == engine
 
+    def test_database_url_with_options(self):
+        del os.environ['DATABASE_URL']
+        a = dj_database_url.config()
+        assert not a
+
+        os.environ['DATABASE_URL'] = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full'
+
+        url = dj_database_url.config()
+
+        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
+        assert url['USER'] == 'uf07k1i6d8ia0v'
+        assert url['PASSWORD'] == 'wegauwhgeuioweg'
+        assert url['PORT'] == 5431
+        assert url['OPTIONS'] == {
+            'sslrootcert': 'rds-combined-ca-bundle.pem',
+            'sslmode': 'verify-full'
+        }
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've confirmed this works two different ways:
1. I've used this to connect to the database and confirm we can use the connection. Using tcpdump verifies that the traffic is not transmitted in plaintext.  (We cannot see the 'SELECT 1' from packet inspection.)
2. I've confirmed that supplying a .pem file for another region (us-west-1) in the option fails.

I won't bother with the tcpdump, here, but Anthony has seen it as well.  However, here's the failure from the second attempt:

```
Traceback (most recent call last):
  File "dj_database_url.py", line 122, in <module>
    main()
  File "dj_database_url.py", line 115, in main
    db.connect()
  File "/Users/j/miniconda/lib/python2.7/site-packages/django/db/backends/__init__.py", line 122, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/Users/j/miniconda/lib/python2.7/site-packages/django/db/backends/postgresql_psycopg2/base.py", line 130, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/Users/j/miniconda/lib/python2.7/site-packages/psycopg2/__init__.py", line 164, in connect
    conn = _connect(dsn, connection_factory=connection_factory, async=async)
psycopg2.OperationalError: SSL error: certificate verify failed
```

So, certificate pinning of the `?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full` sort does seem to work!
