### PR TITLE
preparing to archive this repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-DJ-Database-URL
+[DEPRECATED] DJ-Database-URL
 ~~~~~~~~~~~~~~~
 
 .. image:: https://secure.travis-ci.org/kennethreitz/dj-database-url.png?branch=master


### PR DESCRIPTION
Deprecate our fork of `dj-database-url`. All libs that were using this fork have been updated to use the original lib:
https://github.com/pulls?q=is%3Apr+author%3Asuavesav+archived%3Afalse+dj-database+is%3Aclosed
 * analytics-api
 * clever-sync
 * deploy-api

Other libs that are using this are deprecated:
 * AltSchool/sync
 * Altschool/sensor-sea-cache-backend
 * AltSchool/apollo-backend-deprecated